### PR TITLE
Copy image classes to viewer image

### DIFF
--- a/src/teachbooks_zoomies/static/viewer_custom.js
+++ b/src/teachbooks_zoomies/static/viewer_custom.js
@@ -86,6 +86,12 @@ document.addEventListener("DOMContentLoaded", function() {
 
                 // C. INITIAL ZOOM
                 viewed() {
+                    // Transfer all classes from original img to the viewer's image
+                    if (viewer.image && target.classList.length > 0) {
+                        Array.from(target.classList).forEach(cls => {
+                            viewer.image.classList.add(cls);
+                        });
+                    }
                     // Measure footer (caption + toolbar) and push the canvas up so the image
                     // never sits behind the caption area.
                     captionHeight = viewer.footer ? viewer.footer.offsetHeight : 0;


### PR DESCRIPTION
When the viewer initializes, copy all CSS classes from the original target image to the viewer's image so styling (borders, filters, custom classes) is preserved in the zoomed view. Adds a check that viewer.image exists and target has classes before copying. Placed in the initial viewed() logic prior to measuring caption/footer.