### PR TITLE
Preserve original image styles in viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A simple Sphinx extension to integrate [Viewer.js](https://github.com/fengyuanch
 - **Theme Integrated:** Automatically adapts to light and dark modes, using your theme's native colors.
 - **Smart Captions:** Automatically pulls captions from `<figure>` elements to display them in the viewer.
 - **Best-Fit Logic:** Intelligently scales images to fit your viewport (configurable).
-- **Dark Mode Optimization:** Option to automatically invert image colors in dark mode—perfect for scientific plots with white backgrounds.
 - **Customizable Toolbar:** Choose exactly which tools (zoom, rotate, reset) are available to your readers.
 
 ## Installation
@@ -54,8 +53,6 @@ TeachBooks Zoomies works out-of-the-box with PyData-based themes (like the Jupyt
 | `zoomies_selector` | `".bd-article img"` | CSS selector for images that should be zoomable. |
 | `zoomies_best_fit` | `70` | Initial zoom level as a % of the viewport (1-100). |
 | `zoomies_toolbar` | `["zoomIn", "zoomOut", "oneToOne", "reset"]` | Tools to show. Options: `zoomIn`, `zoomOut`, `oneToOne`, `reset`, `prev`, `play`, `next`, `rotateLeft`, `rotateRight`, `flipHorizontal`, `flipVertical`. |
-| `zoomies_invert_colors` | `false` | Inverts image colors in dark mode. Useful for charts with white backgrounds. |
-| `zoomies_bg_apply_to_img` | `true` | If true, adds a background/padding directly to the image. If false, colors the entire backdrop. |
 | `zoomies_bg_color_light` | `"rgba(255, 255, 255, 0.95)"` | Viewer background color in light mode. |
 | `zoomies_bg_color_dark` | `"#333"` | Viewer background color in dark mode. |
 | `zoomies_caption_color_light`| `"var(--pst-color-text-base)"` | Caption text color in light mode. |
@@ -71,7 +68,6 @@ sphinx:
     zoomies_selector: ".bd-article img, .my-custom-image-class"
     zoomies_best_fit: 85
     zoomies_toolbar: ["zoomIn", "zoomOut", "reset", "rotateRight"]
-    zoomies_invert_colors: false
 ```
 
 ### Example `conf.py` (Sphinx)
@@ -79,5 +75,4 @@ sphinx:
 ```python
 zoomies_selector = ".bd-article img"
 zoomies_best_fit = 80
-zoomies_invert_colors = True
 ```

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ TeachBooks Zoomies works out-of-the-box with PyData-based themes (like the Jupyt
 | `zoomies_selector` | `".bd-article img"` | CSS selector for images that should be zoomable. |
 | `zoomies_best_fit` | `70` | Initial zoom level as a % of the viewport (1-100). |
 | `zoomies_toolbar` | `["zoomIn", "zoomOut", "oneToOne", "reset"]` | Tools to show. Options: `zoomIn`, `zoomOut`, `oneToOne`, `reset`, `prev`, `play`, `next`, `rotateLeft`, `rotateRight`, `flipHorizontal`, `flipVertical`. |
-| `zoomies_bg_color_light` | `"rgba(255, 255, 255, 0.95)"` | Viewer background color in light mode. |
-| `zoomies_bg_color_dark` | `"#333"` | Viewer background color in dark mode. |
+| `zoomies_bg_color_light` | `"color-mix(in srgb, var(--pst-color-background) 95%, transparent)"` | Viewer background color in light mode. |
+| `zoomies_bg_color_dark` | `"color-mix(in srgb, var(--pst-color-background) 95%, transparent)"` | Viewer background color in dark mode. |
 | `zoomies_caption_color_light`| `"var(--pst-color-text-base)"` | Caption text color in light mode. |
 | `zoomies_caption_color_dark` | `"var(--pst-color-text-base)"` | Caption text color in dark mode. |
 | `zoomies_cdn_css` | `"...viewer.min.css"` | URL for the Viewer.js CSS file. |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ TeachBooks Zoomies works out-of-the-box with PyData-based themes (like the Jupyt
 | `zoomies_bg_color_dark` | `"color-mix(in srgb, var(--pst-color-background) 95%, transparent)"` | Viewer background color in dark mode. |
 | `zoomies_caption_color_light`| `"var(--pst-color-text-base)"` | Caption text color in light mode. |
 | `zoomies_caption_color_dark` | `"var(--pst-color-text-base)"` | Caption text color in dark mode. |
-| `zoomies_cdn_css` | `"...viewer.min.css"` | URL for the Viewer.js CSS file. |
-| `zoomies_cdn_js` | `"...viewer.min.js"` | URL for the Viewer.js JS file. |
+| `zoomies_cdn_css` | `"https://unpkg.com/viewerjs/dist/viewer.min.css"` | URL for the Viewer.js CSS file. |
+| `zoomies_cdn_js` | `"https://unpkg.com/viewerjs/dist/viewer.min.js"` | URL for the Viewer.js JS file. |
 
 ### Example `_config.yml` (Jupyter Book)
 

--- a/src/teachbooks_zoomies/__init__.py
+++ b/src/teachbooks_zoomies/__init__.py
@@ -10,8 +10,6 @@ def setup(app):
     app.add_config_value('zoomies_caption_color_dark', 'var(--pst-color-text-base)', 'html')
     app.add_config_value('zoomies_bg_color_light', 'rgba(255, 255, 255, 0.95)', 'html')
     app.add_config_value('zoomies_bg_color_dark', '#333', 'html')
-    app.add_config_value('zoomies_bg_apply_to_img', True, 'html')
-    app.add_config_value('zoomies_invert_colors', False, 'html')
     app.add_config_value('zoomies_toolbar', ["zoomIn", "zoomOut", "oneToOne", "reset"], 'html')
     app.add_config_value('zoomies_best_fit', 70, 'html')
 
@@ -47,30 +45,17 @@ def inject_assets(app, pagename, templatename, context, doctree):
     # We define the logic here and the mapping in the CSS file.
     
     # Defaults/Light mode
-    bg_color_light = app.config.zoomies_bg_color_light
-    img_bg_light = bg_color_light if app.config.zoomies_bg_apply_to_img else "transparent"
-    backdrop_bg_light = "rgba(0, 0, 0, 0.75)" if app.config.zoomies_bg_apply_to_img else bg_color_light
+    backdrop_bg_light = app.config.zoomies_bg_color_light
     
     # Dark mode
-    bg_color_dark = app.config.zoomies_bg_color_dark
-    
-    if app.config.zoomies_invert_colors and app.config.zoomies_bg_apply_to_img and (bg_color_dark == '#333' or bg_color_dark == 'rgba(0, 0, 0, 0.95)'):
-        # Default behavior: use light background color so it inverts to dark
-        img_bg_dark = bg_color_light
-    else:
-        # Respect custom background color (it will be inverted if applied to the img tag)
-        img_bg_dark = bg_color_dark if app.config.zoomies_bg_apply_to_img else "transparent"
-        
-    backdrop_bg_dark = "rgba(0, 0, 0, 0.85)" if app.config.zoomies_bg_apply_to_img else bg_color_dark
+    backdrop_bg_dark = app.config.zoomies_bg_color_dark
 
-    img_padding = "15px" if app.config.zoomies_bg_apply_to_img else "0"
-    img_rounded = "8px" if app.config.zoomies_bg_apply_to_img else "0"
+    img_padding = "0"
+    img_rounded = "0"
 
     style = f"""
     :root {{
-        --zoomies-bg-color: {bg_color_light};
         --zoomies-caption-color: {app.config.zoomies_caption_color_light};
-        --zoomies-img-bg: {img_bg_light};
         --zoomies-backdrop-bg: {backdrop_bg_light};
         --zoomies-img-padding: {img_padding};
         --zoomies-img-rounded: {img_rounded};
@@ -79,59 +64,22 @@ def inject_assets(app, pagename, templatename, context, doctree):
     /* Robust dark mode detection */
     @media (prefers-color-scheme: dark) {{
         :root {{
-            --zoomies-bg-color: {bg_color_dark};
             --zoomies-caption-color: {app.config.zoomies_caption_color_dark};
-            --zoomies-img-bg: {img_bg_dark};
             --zoomies-backdrop-bg: {backdrop_bg_dark};
         }}
     }}
 
     html[data-theme="dark"], body[data-theme="dark"], [data-theme="dark"], .theme-dark, .dark {{
-        --zoomies-bg-color: {bg_color_dark} !important;
         --zoomies-caption-color: {app.config.zoomies_caption_color_dark} !important;
-        --zoomies-img-bg: {img_bg_dark} !important;
         --zoomies-backdrop-bg: {backdrop_bg_dark} !important;
     }}
 
     html[data-theme="light"], body[data-theme="light"], [data-theme="light"], .theme-light, .light {{
-        --zoomies-bg-color: {bg_color_light} !important;
         --zoomies-caption-color: {app.config.zoomies_caption_color_light} !important;
-        --zoomies-img-bg: {img_bg_light} !important;
         --zoomies-backdrop-bg: {backdrop_bg_light} !important;
     }}
     """
     
-    if app.config.zoomies_invert_colors:
-        style += f"""
-    /* Hide scrollbar for primary and secondary sidebars */
-    .bd-sidebar-primary,
-    .bd-sidebar-secondary {{
-        -ms-overflow-style: none;  /* IE and Edge */
-        scrollbar-width: none;  /* Firefox */
-        overflow-y: auto !important; /* Keep it scrollable but hide the bar */
-    }}
-
-    .bd-sidebar-primary::-webkit-scrollbar,
-    .bd-sidebar-secondary::-webkit-scrollbar {{
-        display: none; /* Chrome, Safari and Opera */
-    }}
-
-    /* Global image inversion in dark mode */
-    html[data-theme="dark"] img, 
-    html[data-theme="dark"] .cell_output img, 
-    html[data-theme="dark"] .rendered_html img {{
-        filter: invert(1) hue-rotate(180deg) !important;
-        mix-blend-mode: normal !important; 
-        isolation: isolate;
-        background-color: transparent !important;
-    }}
-
-    /* Specific override for the Viewer.js image to allow its background to be inverted correctly */
-    html[data-theme="dark"] .viewer-canvas img {{
-        background-color: {img_bg_dark} !important;
-    }}
-    """
-
     app.add_js_file(None, body=f"const style = document.createElement('style'); style.textContent = `{style}`; document.head.appendChild(style);")
 
     # D. Inject our Custom Logic and Styles

--- a/src/teachbooks_zoomies/__init__.py
+++ b/src/teachbooks_zoomies/__init__.py
@@ -8,8 +8,8 @@ def setup(app):
     app.add_config_value('zoomies_cdn_js', 'https://unpkg.com/viewerjs/dist/viewer.min.js', 'html')
     app.add_config_value('zoomies_caption_color_light', 'var(--pst-color-text-base)', 'html')
     app.add_config_value('zoomies_caption_color_dark', 'var(--pst-color-text-base)', 'html')
-    app.add_config_value('zoomies_bg_color_light', 'rgba(255, 255, 255, 0.95)', 'html')
-    app.add_config_value('zoomies_bg_color_dark', '#333', 'html')
+    app.add_config_value('zoomies_bg_color_light', 'color-mix(in srgb, var(--pst-color-background) 95%, transparent)', 'html')
+    app.add_config_value('zoomies_bg_color_dark', 'color-mix(in srgb, var(--pst-color-background) 95%, transparent)', 'html')
     app.add_config_value('zoomies_toolbar', ["zoomIn", "zoomOut", "oneToOne", "reset"], 'html')
     app.add_config_value('zoomies_best_fit', 70, 'html')
 

--- a/src/teachbooks_zoomies/__init__.py
+++ b/src/teachbooks_zoomies/__init__.py
@@ -12,6 +12,9 @@ def setup(app):
     app.add_config_value('zoomies_bg_color_dark', 'color-mix(in srgb, var(--pst-color-background) 95%, transparent)', 'html')
     app.add_config_value('zoomies_toolbar', ["zoomIn", "zoomOut", "oneToOne", "reset"], 'html')
     app.add_config_value('zoomies_best_fit', 70, 'html')
+    # decrepated options - might be removed in future versions - have no influence on the current implementation but are kept for backward compatibility
+    app.add_config_value('zoomies_bg_apply_to_img', True, 'html')
+    app.add_config_value('zoomies_invert_colors', False, 'html')
 
     # 2. Hook: Inject assets into the HTML
     app.connect('builder-inited', on_builder_inited)
@@ -43,40 +46,29 @@ def inject_assets(app, pagename, templatename, context, doctree):
 
     # C. Inject Theme Colors as CSS Variables
     # We define the logic here and the mapping in the CSS file.
-    
-    # Defaults/Light mode
-    backdrop_bg_light = app.config.zoomies_bg_color_light
-    
-    # Dark mode
-    backdrop_bg_dark = app.config.zoomies_bg_color_dark
-
-    img_padding = "0"
-    img_rounded = "0"
 
     style = f"""
     :root {{
         --zoomies-caption-color: {app.config.zoomies_caption_color_light};
-        --zoomies-backdrop-bg: {backdrop_bg_light};
-        --zoomies-img-padding: {img_padding};
-        --zoomies-img-rounded: {img_rounded};
+        --zoomies-backdrop-bg: {app.config.zoomies_bg_color_light};
     }}
 
     /* Robust dark mode detection */
     @media (prefers-color-scheme: dark) {{
         :root {{
             --zoomies-caption-color: {app.config.zoomies_caption_color_dark};
-            --zoomies-backdrop-bg: {backdrop_bg_dark};
+            --zoomies-backdrop-bg: {app.config.zoomies_bg_color_dark};
         }}
     }}
 
     html[data-theme="dark"], body[data-theme="dark"], [data-theme="dark"], .theme-dark, .dark {{
         --zoomies-caption-color: {app.config.zoomies_caption_color_dark} !important;
-        --zoomies-backdrop-bg: {backdrop_bg_dark} !important;
+        --zoomies-backdrop-bg: {app.config.zoomies_bg_color_dark} !important;
     }}
 
     html[data-theme="light"], body[data-theme="light"], [data-theme="light"], .theme-light, .light {{
         --zoomies-caption-color: {app.config.zoomies_caption_color_light} !important;
-        --zoomies-backdrop-bg: {backdrop_bg_light} !important;
+        --zoomies-backdrop-bg: {app.config.zoomies_bg_color_light} !important;
     }}
     """
     

--- a/src/teachbooks_zoomies/static/viewer_custom.css
+++ b/src/teachbooks_zoomies/static/viewer_custom.css
@@ -55,3 +55,11 @@
 .viewer-canvas {
     background-color: transparent !important;
 }
+
+html:not([data-theme=dark]) body.high-contrast.viewer-open {
+    filter: none !important;
+}
+
+html[data-theme=dark] body.high-contrast.viewer-open {
+    filter: none !important;
+}

--- a/src/teachbooks_zoomies/static/viewer_custom.css
+++ b/src/teachbooks_zoomies/static/viewer_custom.css
@@ -1,3 +1,9 @@
+/* root variables for dynamic theming */
+:root {
+    --zoomies-img-padding: 0;
+    --zoomies-img-rounded: 0;
+}
+
 /* --- Base Styles for Caption --- */
 .viewer-title {
     font-size: 1.25rem !important;

--- a/src/teachbooks_zoomies/static/viewer_custom.css
+++ b/src/teachbooks_zoomies/static/viewer_custom.css
@@ -36,8 +36,7 @@
 }
 
 /* 2. Image Background (for transparent images) */
-.viewer-container .viewer-canvas > img {
-    background-color: var(--zoomies-img-bg) !important;
+.viewer-container .viewer-canvas img {
     padding: var(--zoomies-img-padding, 0) !important;
     border-radius: var(--zoomies-img-rounded, 0) !important;
     
@@ -50,9 +49,6 @@
     flex-shrink: 0 !important;
     min-width: 0 !important;
     min-height: 0 !important;
-
-    /* Extra visibility: subtle border in dark mode if it's the image background */
-    box-shadow: 0 0 0 1px rgba(255,255,255,0.05) !important;
 }
 
 /* Ensure the canvas itself is transparent */

--- a/src/teachbooks_zoomies/static/viewer_custom.css
+++ b/src/teachbooks_zoomies/static/viewer_custom.css
@@ -35,7 +35,7 @@
     background-color: var(--zoomies-backdrop-bg) !important;
 }
 
-/* 2. Image Background (for transparent images) */
+/* 2. Image Styles */
 .viewer-container .viewer-canvas img {
     padding: var(--zoomies-img-padding, 0) !important;
     border-radius: var(--zoomies-img-rounded, 0) !important;

--- a/src/teachbooks_zoomies/static/viewer_custom.js
+++ b/src/teachbooks_zoomies/static/viewer_custom.js
@@ -157,7 +157,6 @@ document.addEventListener("DOMContentLoaded", function() {
             if (hc) {
                 // store filter in high-contrast mode so we can re-apply it to the viewer container later
                 bodyFilter = window.getComputedStyle(document.body).filter;
-                void document.body.offsetWidth; // force reflow so both changes apply synchronously
             };
 
             const viewer = new Viewer(target, {
@@ -232,9 +231,6 @@ document.addEventListener("DOMContentLoaded", function() {
                 },
 
                 hidden: function() {
-                    if (hc) {
-                        void document.body.offsetWidth;
-                    };
                     viewer.destroy();
                 }
             });

--- a/src/teachbooks_zoomies/static/viewer_custom.js
+++ b/src/teachbooks_zoomies/static/viewer_custom.js
@@ -151,6 +151,15 @@ document.addEventListener("DOMContentLoaded", function() {
                 }
             });
 
+            // Check if high-contrast mode is enabled
+            const hc = document.body.classList.contains('high-contrast');
+            let bodyFilter = 'none';
+            if (hc) {
+                // store filter in high-contrast mode so we can re-apply it to the viewer container later
+                bodyFilter = window.getComputedStyle(document.body).filter;
+                void document.body.offsetWidth; // force reflow so both changes apply synchronously
+            };
+
             const viewer = new Viewer(target, {
                 // A. CAPTION LOGIC — return plain text; HTML is injected in viewed()
                 title: function (image) {
@@ -195,7 +204,10 @@ document.addEventListener("DOMContentLoaded", function() {
                     // Build a NESTED wrapper chain from the original ancestors
                     const ancestors = [];
                     let el = target.parentElement;
-                    while (el) { ancestors.push(el); el = el.parentElement; }
+                    while (el) {
+                        ancestors.push(el);
+                        el = el.parentElement;
+                    }
                     // We want the outermost ancestor to be the outer wrapper;
                     // buildNestedFromAncestors expects ancestors in DOM order from nearest -> farthest
                     // but it wraps in that order so the last becomes the outermost—this is fine.
@@ -211,9 +223,18 @@ document.addEventListener("DOMContentLoaded", function() {
 
 
                     applyBestFit(viewer, captionHeight);
+
+                    // Re-apply body filter (e.g. high-contrast) directly to the viewer
+                    // container so the effect is preserved without breaking position:fixed.
+                    if (hc) {
+                        viewer.canvas.style.setProperty('filter', bodyFilter, 'important');
+                    }
                 },
 
                 hidden: function() {
+                    if (hc) {
+                        void document.body.offsetWidth;
+                    };
                     viewer.destroy();
                 }
             });

--- a/src/teachbooks_zoomies/static/viewer_custom.js
+++ b/src/teachbooks_zoomies/static/viewer_custom.js
@@ -1,5 +1,88 @@
 document.addEventListener("DOMContentLoaded", function() {
 
+    const props_img = [
+        "background",
+        "border",
+        "border-block",
+        "border-inline",
+        "border-image",
+        "outline",
+        "box-shadow",
+        "filter",
+        "opacity",
+        "mix-blend-mode",
+        "background-blend-mode",
+        "clip-path",
+        "mask",
+        "transform",
+        "transform-origin",
+        "transform-style",
+        "perspective",
+        "perspective-origin",
+        "backface-visibility",
+        "isolation",
+        "backdrop-filter",
+        "cursor",
+        "pointer-events",
+        "user-select",
+        "appearance",
+        "accent-color",
+        "caret-color",
+        "scrollbar-color",
+        "scrollbar-width"
+    ];
+
+    const props_divs = [
+        "background",
+        "filter",
+        "opacity",
+        "mix-blend-mode",
+        "background-blend-mode",
+        "transform",
+        "transform-origin",
+        "transform-style",
+        "backface-visibility",
+        "isolation",
+        "backdrop-filter",
+    ];
+
+    
+    function extractSubset(computed, props) {
+        const out = {};
+        for (const p of props) {
+            out[p] = computed.getPropertyValue(p);
+        }
+        return out;
+    }
+
+    
+    // Helper: apply a subset object as inline styles
+    function applySubsetInline(el, subset) {
+        for (const [k, v] of Object.entries(subset)) {
+            if (v && v.trim() !== "" && v !== "none") {
+                el.style.setProperty(k, v);
+            }
+        }
+    }
+
+    // Helper: build nested wrappers from ancestor list (outermost last)
+    function buildNestedFromAncestors(ancestors, leaf, props) {
+        let current = leaf;
+        for (const anc of ancestors) {
+            const cs = getComputedStyle(anc);
+            const subset = extractSubset(cs, props);
+            const wrapper = document.createElement("div");
+            // neutralize layout influence
+            wrapper.style.margin = "0";
+            wrapper.style.padding = "0";
+            // no explicit width/height per your requirement
+            applySubsetInline(wrapper, subset);
+            wrapper.appendChild(current);
+            current = wrapper;
+        }
+        return current;
+    }
+
     // --- 1. CONFIGURATION ---
     // Read the config injected by our Python extension
     const selector = (window.ViewerConfig && window.ViewerConfig.selector) || '.bd-article img';
@@ -103,6 +186,30 @@ document.addEventListener("DOMContentLoaded", function() {
                         const titleEl = viewer.footer && viewer.footer.querySelector('.viewer-title');
                         if (titleEl) titleEl.innerHTML = captionHTML;
                     }
+                    
+                    // Apply SAME visual subset from original image to the actual viewer image
+                    const originalCS = getComputedStyle(target);
+                    const originalSubset = extractSubset(originalCS, props_img);
+                    applySubsetInline(viewer.image, originalSubset);
+
+                    // Build a NESTED wrapper chain from the original ancestors
+                    const ancestors = [];
+                    let el = target.parentElement;
+                    while (el) { ancestors.push(el); el = el.parentElement; }
+                    // We want the outermost ancestor to be the outer wrapper;
+                    // buildNestedFromAncestors expects ancestors in DOM order from nearest -> farthest
+                    // but it wraps in that order so the last becomes the outermost—this is fine.
+
+                    const nested = buildNestedFromAncestors(ancestors, viewer.image, props_divs);
+
+                    // Replace viewer canvas content with our nested reconstruction
+                    if (viewer.canvas) {
+                        // preserve the canvas node; just replace its children
+                        while (viewer.canvas.firstChild) viewer.canvas.removeChild(viewer.canvas.firstChild);
+                        viewer.canvas.appendChild(nested);
+                    }
+
+
                     applyBestFit(viewer, captionHeight);
                 },
 


### PR DESCRIPTION
Copy a subset of computed CSS from the original image and its ancestor elements into the zoom viewer so the displayed image matches page styling. Added lists of image/div properties, helper functions (extractSubset, applySubsetInline, buildNestedFromAncestors) and logic to apply inline styles to viewer.image and to build nested wrapper divs from the original element ancestors (neutralizing margin/padding and avoiding explicit width/height). This preserves visual effects (filters, transforms, blends, etc.) when the image is opened in the viewer without altering existing viewer sizing logic.

Can be tested by (locally) performing the next commands first:

```cli
pip uninstall -y teachbooks-zoomies
pip install --no-cache git+https://github.com/TeachBooks/TeachBooks-Zoomies@background
```

Ignore compatibility remarks of `pip`.

Then building as usual.